### PR TITLE
修复NewReaderSize和NewWriterSize加粗格式显示异常

### DIFF
--- a/lesson04/第四节课.md
+++ b/lesson04/第四节课.md
@@ -562,7 +562,7 @@ type Reader struct {
 
 **NewReader**:创建Reader
 
-**NewReaderSize:**创建自定义大小的缓冲
+**NewReaderSize**:创建自定义大小的缓冲
 
 ```go
 func NewReader(rd io.Reader) *Reader
@@ -605,7 +605,7 @@ func (b *Reader) ReadRune() (r rune, size int, err error)
 
 **NewWriter**:创建Writer
 
-**NewWriterSize:**创建自定义大小的缓冲
+**NewWriterSize**:创建自定义大小的缓冲
 
 ```go
 func NewWriter(w io.Writer) *Writer


### PR DESCRIPTION
在 GitHub 上查看文档时，发现 NewReaderSize 和 NewWriterSize 方法的加粗格式显示异常，似乎是GitHub 的 Markdown 解析器对语法要求比较严格，在typora上可以，但在GitHub上不行，当加粗语法后紧跟中文字符时，可能导致格式渲染不正确。

此次修改仅涉及文档格式优化，不会影响功能使用。