### PR TITLE
fix: lesson16.md 中 go get 仅拉取 eino 和 eino-ext 后编译示例代码会报依赖错误

### DIFF
--- a/lesson16/lesson16.md
+++ b/lesson16/lesson16.md
@@ -51,6 +51,7 @@ think → act → observe → think → ...
 ```bash
 go get github.com/cloudwego/eino
 go get github.com/cloudwego/eino-ext
+go get github.com/cloudwego/eino-ext/components/model/ollama
 ```
 
 ### 示例：调用 LLM + 使用模板


### PR DESCRIPTION
`lesson16.md` 中 `go get` 仅拉取 `eino` 和 `eino-ext` 后编译示例代码会报依赖错误 需额外拉取 `eino-ext/components/model/ollama`