### PR TITLE
更新了sarama过时的github路径

### DIFF
--- a/lesson13/13.md
+++ b/lesson13/13.md
@@ -260,7 +260,7 @@ docker rm kafka
 
 ```bash
 # Sarama 是 Go 生态最稳定的 Kafka 客户端，支持 Kafka 4.x 所有核心功能
-go get github.com/Shopify/sarama
+go get github.com/IBM/sarama
 ```
 
 安装完成后，若提示依赖冲突，可执行 `go mod tidy` 自动整理依赖，即可编写 Go 代码操作 Kafka。
@@ -287,7 +287,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/Shopify/sarama"
+	"github.com/IBM/sarama"
 )
 
 func main() {
@@ -340,7 +340,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/Shopify/sarama"
+	"github.com/IBM/sarama"
 )
 
 func main() {
@@ -414,7 +414,7 @@ go run consumer.go
 
 3. Sarama 库兼容问题
 
-- 若安装 Sarama 后运行代码报错，提示版本不兼容，可执行 go get github.com/Shopify/sarama@v1.42.0（该版本与 Kafka 4.x 兼容性最佳）
+- 若安装 Sarama 后运行代码报错，提示版本不兼容，可执行 go get github.com/IBM/sarama@v1.42.0（该版本与 Kafka 4.x 兼容性最佳）
 
 - 若出现依赖缺失，执行 go mod init kafka-demo（初始化模块）后，再执行 go mod tidy 即可解决。
 


### PR DESCRIPTION
将sarama相关的路径由Shopify/sarama改为IBM/sarama